### PR TITLE
one-301 update gen_all.ps1 to work for pwsh 7

### DIFF
--- a/generators/gen_all.ps1
+++ b/generators/gen_all.ps1
@@ -25,9 +25,9 @@ $logName =  (Get-Date -DisplayHint Time).ToString().Replace(":","_").Replace("/"
 $commandPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 
 # Start-Transcript $logName
-foreach($file in $files)
+foreach($fileName in $files.Name)
 {
-    $Command = "$commandPath\protoc\tool\protoc $flags $file"
+    $Command = "$commandPath\protoc\tool\protoc $flags $fileName"
     echo `n$Command
 
     Invoke-Expression -Command $Command


### PR DESCRIPTION
protoc command generated when run in pwsh 5 includes only the file name of each .proto file 
but pwsh 7 generated commands that included full path for each .proto file, causing "File does not reside within any path" protoc error for each .proto file.

update script to be explicit about needing only the file name, not full path.  this allows script to work for both pwsh 5, 7