### PR TITLE
IH-1226: Updated instrument and IntrumentManifest with ClarosRecordAu…

### DIFF
--- a/proto/one/instrument/core/instrument_data_aggregation_summary.proto
+++ b/proto/one/instrument/core/instrument_data_aggregation_summary.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/wrappers.proto";
 import "jsonTicksDateTime.proto";
 import "measurement_statistic.proto";
 

--- a/proto/one/instrument/core/instrument_detail_summary.proto
+++ b/proto/one/instrument/core/instrument_detail_summary.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 import "google/protobuf/wrappers.proto";
 import "instrument_manifest_summary.proto";
 import "enum_connection_status.proto";
+import "claros_jsonTicksDateTime.proto";
+import "enum_connection_status_reason.proto";
 
 option csharp_namespace = "ONE.Models.CSharp.Instrument";
 
@@ -35,6 +37,12 @@ message InstrumentDetailSummary {
 
   // Instrument name
   google.protobuf.StringValue instrumentName = 8;
+
+  // Specifies the reason for the connection status change
+  EnumConnectionStatusReason connectionStatusReason = 9;
+
+  // Specifies the time when the connection status was last changed
+  ClarosJsonTicksDateTime connectionStatusChangedOn = 10;
 }
 
 message InstrumentDetailSummaries {

--- a/proto/one/instrument/core/instrument_detail_summary.proto
+++ b/proto/one/instrument/core/instrument_detail_summary.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 import "google/protobuf/wrappers.proto";
 import "instrument_manifest_summary.proto";
 import "enum_connection_status.proto";
-import "claros_jsonTicksDateTime.proto";
+import "jsonTicksDateTime.proto";
 import "enum_connection_status_reason.proto";
 
 option csharp_namespace = "ONE.Models.CSharp.Instrument";
@@ -42,7 +42,7 @@ message InstrumentDetailSummary {
   EnumConnectionStatusReason connectionStatusReason = 9;
 
   // Specifies the time when the connection status was last changed
-  ClarosJsonTicksDateTime connectionStatusChangedOn = 10;
+  JsonTicksDateTime connectionStatusChangedOn = 10;
 }
 
 message InstrumentDetailSummaries {

--- a/proto/one/instrument/twin/enum_connection_status_reason.proto
+++ b/proto/one/instrument/twin/enum_connection_status_reason.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+import "enum_connection_status_reason.proto";
+import "clarosdatetime.proto";
+
+
+option csharp_namespace ="ONE.Models.CSharp.Instrument";
+
+enum EnumConnectionStatusReason {
+    CONNECTION_STATUS_REASON_UNKNOWN = 0;
+    CONNECTION_STATUS_REASON_REPORTED = 1;
+    CONNECTION_STATUS_REASON_HEARTBEAT = 2;
+    CONNECTION_STATUS_REASON_PARENT_DISCONNECTED = 3;
+    CONNECTION_STATUS_REASON_PARENT_INITIALIZE = 4;
+}

--- a/proto/one/instrument/twin/enum_connection_status_reason.proto
+++ b/proto/one/instrument/twin/enum_connection_status_reason.proto
@@ -1,9 +1,5 @@
 syntax = "proto3";
 
-import "enum_connection_status_reason.proto";
-import "clarosdatetime.proto";
-
-
 option csharp_namespace ="ONE.Models.CSharp.Instrument";
 
 enum EnumConnectionStatusReason {

--- a/proto/one/instrument/twin/external/claros_record_auditinfo.proto
+++ b/proto/one/instrument/twin/external/claros_record_auditinfo.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "claros_jsonTicksDateTime.proto";
 
-option csharp_namespace ="ONE.Models.CSharp";
+option csharp_namespace ="ONE.Models.CSharp.External";
 
 message ClarosRecordAuditInfo {
     string createdById = 1 [json_name = "cbid"];

--- a/proto/one/instrument/twin/external/claros_record_auditinfo.proto
+++ b/proto/one/instrument/twin/external/claros_record_auditinfo.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+import "claros_jsonTicksDateTime.proto";
+
+option csharp_namespace ="ONE.Models.CSharp";
+
+message ClarosRecordAuditInfo {
+    string createdById = 1 [json_name = "cbid"];
+    ClarosJsonTicksDateTime createdOn = 2 [json_name = "co"];
+    string modifiedById = 3 [json_name = "mbid"];
+    ClarosJsonTicksDateTime modifiedOn = 4 [json_name = "mo"];
+}

--- a/proto/one/instrument/twin/instrument.proto
+++ b/proto/one/instrument/twin/instrument.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/wrappers.proto";
-import "record_auditinfo.proto";
+import "claros_record_auditinfo.proto";
 import "instrument_reference.proto";
 import "enum_connection_status.proto";
 import "enum_instrument_registry_status.proto";
@@ -26,7 +26,7 @@ message Instrument {
     EnumInstrumentRegistryStatus registryStatus = 5;
 
     // Record audit information
-    RecordAuditInfo recordAuditInfo = 99;
+    ClarosRecordAuditInfo recordAuditInfo = 99;
 }
 
 // Represents a list of instruments

--- a/proto/one/instrument/twin/instrument.proto
+++ b/proto/one/instrument/twin/instrument.proto
@@ -5,6 +5,8 @@ import "claros_record_auditinfo.proto";
 import "instrument_reference.proto";
 import "enum_connection_status.proto";
 import "enum_instrument_registry_status.proto";
+import "claros_jsonTicksDateTime.proto";
+import "enum_connection_status_reason.proto";
 
 option csharp_namespace ="ONE.Models.CSharp.Instrument";
 
@@ -24,6 +26,12 @@ message Instrument {
 
     // Specifies the registry status of the instrument
     EnumInstrumentRegistryStatus registryStatus = 5;
+
+    // Specifies the reason for the connection status change
+    EnumConnectionStatusReason connectionStatusReason = 6;
+
+    // Specifies the time when the connection status was last changed
+    ClarosJsonTicksDateTime connectionStatusChangedOn = 7;
 
     // Record audit information
     ClarosRecordAuditInfo recordAuditInfo = 99;

--- a/proto/one/instrument/twin/manifest/instrument_manifest.proto
+++ b/proto/one/instrument/twin/manifest/instrument_manifest.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/wrappers.proto";
-import "record_auditinfo.proto";
+import "claros_record_auditinfo.proto";
 import "instrument_group.proto";
 import "instrument_type.proto";
 import "instrument_measurement_capability.proto";
@@ -57,6 +57,5 @@ message InstrumentManifest {
     // Specifies the warning capabilities and related meta-data for an instrument-type.
     InstrumentWarningCapability instrumentWarningCapability = 18;
 
-    
-    RecordAuditInfo recordAuditInfo = 99;
+    ClarosRecordAuditInfo recordAuditInfo = 99;
 }


### PR DESCRIPTION
Added ClrosRecordAudit class as external class.
Reason : to support Claros Registry events, Since It uses Claros Protobuff and at IH side it was failing to parse jsonstring.

**ONE.Interfaces.CSharp PR** 
https://github.com/AquaticInformatics/ONE.Interfaces.CSharp/pull/124