### PR TITLE
IH-1164: Removed tagNumber from InstrumentMeasurementDefinitionSummary

### DIFF
--- a/proto/one/instrument/core/instrument_measurement_definition_summary.proto
+++ b/proto/one/instrument/core/instrument_measurement_definition_summary.proto
@@ -20,9 +20,6 @@ message InstrumentMeasurementDefinitionSummary {
 
   // Instrument source of this specific parameter
   google.protobuf.UInt32Value channelNumber = 5;
-
-  // Represents tag number of this specific parameter
-  google.protobuf.UInt32Value tagNumber = 6;
 }
 
 // Represents a list of instruments


### PR DESCRIPTION
This PR is to undo the changes done as part of https://github.com/AquaticInformatics/ONE.Interfaces.ProtocolBuffers/pull/125